### PR TITLE
use IsWorldPawn instead of defaultVec to not have the error

### DIFF
--- a/1.4/Source/WWE/HediffGivers/Mountain_Poisoning_Hediff.cs
+++ b/1.4/Source/WWE/HediffGivers/Mountain_Poisoning_Hediff.cs
@@ -1,4 +1,5 @@
 ﻿using RimWorld;
+using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,19 +14,19 @@ namespace WWE.HediffGivers
     public class Mountain_Poisoning : HediffGiver
     {
         private const int PoisonCheckInterval = 420;
-        private static IntVec3 defaultVec = new IntVec3(-1000, -1000, -1000);
 
         public static readonly string MemoPawnBurnedByAir = "Pawn sufficated in toxin";
 
 
         public override void OnIntervalPassed(Pawn pawn, Hediff cause)
         {
-            IntVec3 pos = pawn.Position;
-            if (pos == defaultVec) { return; }
+            if (pawn.IsWorldPawn()) { return; }
+
             if (!pawn.Map.GameConditionManager.ConditionIsActive(GameConditionDef.Named("WWE_Poison_Mountains")))
             {
                 return;
             }
+            IntVec3 pos = pawn.Position;
 
             Hediff h = pawn.health.hediffSet.GetFirstHediffOfDef(hediff);
             RoofDef rooftype = pos.GetRoof(pawn.Map);

--- a/1.4/Source/WWE/HediffGivers/Transitioning_Hediff.cs
+++ b/1.4/Source/WWE/HediffGivers/Transitioning_Hediff.cs
@@ -1,4 +1,5 @@
 ﻿using RimWorld;
+using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,15 +14,15 @@ namespace WWE.HediffGivers
     {
         private const int TransitionCheckInterval = 420;
 
-        private static IntVec3 defaultVec = new IntVec3(-1000, -1000, -1000);
         public override void OnIntervalPassed(Pawn pawn, Hediff cause)
         {
-            IntVec3 pos = pawn.Position;
-            if (pos == defaultVec) { return; }
+            if (pawn.IsWorldPawn()) { return; }
             if (!pawn.Map.GameConditionManager.ConditionIsActive(GameConditionDef.Named("WWE_Genderfluid_Rain")))
             {
                 return;
             }
+
+            IntVec3 pos = pawn.Position;
             Hediff h = pawn.health.hediffSet.GetFirstHediffOfDef(hediff);
             if (pawn.Map.roofGrid.Roofed(pos))
             {


### PR DESCRIPTION
The no reference exception is fixed. Also fixed it in genderfluid rain, since that was the same fix.